### PR TITLE
Env setup adding issuing and proofing to CLI samples

### DIFF
--- a/cmd/connection/reqproof.go
+++ b/cmd/connection/reqproof.go
@@ -10,10 +10,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var reqProofDoc = `Requests a proof from DIDComm's other end agent.
+
+Note! This just a simple command to test newly created credentials and not meant
+to be used in production. For example, it doesn't have proper error handling,
+timeouts, etc.`
+
 var reqProofCmd = &cobra.Command{
 	Use:   "reqproof",
-	Short: "request proof command",
-	Long:  `Requests a proof from DIDComm's other end agent.`,
+	Short: "Request a proof and wait status",
+	Long:  reqProofDoc,
 	PreRunE: func(c *cobra.Command, args []string) (err error) {
 		defer err2.Return(&err)
 		err2.Check(cmd.BindEnvs(envs, ""))
@@ -37,7 +43,7 @@ var reqProofCmd = &cobra.Command{
 		ch, err := client.Pairwise{ID: CmdData.ConnID, Conn: conn}.ReqProof(ctx, attrJSON)
 		err2.Check(err)
 		for status := range ch {
-			fmt.Println("issue status:", status.State, "|", status.Info)
+			fmt.Println("proof request status:", status.State, "|", status.Info)
 		}
 		return nil
 	},

--- a/scripts/fullstack/admin/cli-env
+++ b/scripts/fullstack/admin/cli-env
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-printenv | grep FCLI_$1
+printenv | grep -i FCLI_$1
 

--- a/scripts/fullstack/government/invitation
+++ b/scripts/fullstack/government/invitation
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cli=${FCLI:-findy-agent-cli}
+
+$cli agent invitation --jwt `$cli authn login -u government` --label government
+

--- a/scripts/fullstack/government/issue-to-bob
+++ b/scripts/fullstack/government/issue-to-bob
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cli=${FCLI:-findy-agent-cli}
+
+$cli connection issue --attrs \
+	    '[{"Name": "name", "Value": "Bob"}, {"Name": "gender", "Value": "man"}, {"Name": "tel", "Value": "39483493"}, {"Name": "email", "Value": "bob@email.com"}]'
+    
+

--- a/scripts/fullstack/government/login
+++ b/scripts/fullstack/government/login
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cli=${FCLI:-findy-agent-cli}
+
+export FCLI_USER=government
+export FCLI_JWT=`$cli authn login`
+

--- a/scripts/fullstack/government/new-cred-def
+++ b/scripts/fullstack/government/new-cred-def
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cli=${FCLI:-findy-agent-cli}
+
+export FCLI_CRED_DEF_ID=`$cli agent create-cred-def -t TAG -i "$FCLI_SCHEMA_ID"`
+

--- a/scripts/fullstack/government/new-schema
+++ b/scripts/fullstack/government/new-schema
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cli=${FCLI:-findy-agent-cli}
+
+export FCLI_SCHEMA_ID=`$cli agent create-schema -a new-id -v 1.0 name gender tel email`
+

--- a/scripts/fullstack/government/proofreq-from-bob
+++ b/scripts/fullstack/government/proofreq-from-bob
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cli=${FCLI:-findy-agent-cli}
+
+cred_id="$FCLI_CRED_DEF_ID"
+
+attrs=`printf \
+	'[{"Name": "name", "CredDefId": "%s" }, 
+	{"Name": "gender", "CredDefId": "%s" }, 
+	{"Name": "tel", "CredDefId":  "%s" }, 
+	{"Name": "email", "CredDefId":  "%s" }]' $cred_id $cred_id $cred_id $cred_id`
+
+$cli connection reqproof --attrs "$attrs"

--- a/scripts/fullstack/government/register
+++ b/scripts/fullstack/government/register
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cli=${FCLI:-findy-agent-cli}
+
+export FCLI_USER=government
+$cli authn register
+


### PR DESCRIPTION
- fulfilling CLI samples to cover all core protocols
- creating schema and cred def
- adding issuing and proofing
- guides to use `cli agent mode-cmd --auto` to make all work
- fixing documentation and outputs for `req-proof` Cmd
- now everything is covered there is good to make this work with AcaPY later, maybe, ...