### PR TITLE
Silence logs.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/findy-network/findy-agent-cli/utils"
+	"github.com/golang/glog"
 	"github.com/lainio/err2"
 	"github.com/lainio/err2/try"
 	"github.com/spf13/cobra"
@@ -84,7 +85,7 @@ var rootFlags = RootFlags{}
 
 var rootEnvs = map[string]string{
 	"config":   "CONFIG",
-	"logging":  "LOGGING",
+	"logging":  "CLI_LOGGING",
 	"dry-run":  "DRY_RUN",
 	"server":   "SERVER",
 	"tls-path": "TLS_PATH",
@@ -142,7 +143,7 @@ func readConfigFile() {
 		viper.SetConfigFile(rootFlags.cfgFile)
 		// If a config file is found, read it in.
 		if err := viper.ReadInConfig(); err == nil && printInfo {
-			fmt.Println("Using config file:", viper.ConfigFileUsed())
+			glog.V(3).Infoln("Using config file:", viper.ConfigFileUsed())
 		}
 	}
 }


### PR DESCRIPTION
* FCLI_LOGGING env variable is used for both CLI and core agency binary. This makes things sometimes hard when increasing core agency logging level messes up CLI outputs. Suggesting to rename FCLI_LOGGING to FCLI_CLI_LOGGING for cli tool as the logs for it does not need to be configured for it via the env param so often.
* When using config file, the message "Using config file:" is always printed. This prevents piping e.g. for login functionality. Can we switch the message as log print or is there a specific need for this?